### PR TITLE
Null response json

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -45,8 +45,7 @@ abstract class Resource
             throw new ResponseException($e->getMessage(), $e->getCode(), $e);
         }
 
-        $response->getBody()->rewind();
-        $json = json_decode($response->getBody()->getContents(), true);
+        $json = json_decode((string) $response->getBody(), true);
 
         if ($json === null) {
             throw new ResponseException('Unable to parse response string as JSON');

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -46,7 +46,7 @@ abstract class Resource
         }
 
         $response->getBody()->rewind();
-        $json = json_decode($response->getBody()->getContents(), true, JSON_THROW_ON_ERROR);
+        $json = json_decode($response->getBody()->getContents(), true);
 
         if ($json === null) {
             throw new ResponseException('Unable to parse response string as JSON');

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -45,7 +45,9 @@ abstract class Resource
             throw new ResponseException($e->getMessage(), $e->getCode(), $e);
         }
 
-        $json = json_decode($response->getBody()->getContents(), true);
+        $response->getBody()->rewind();
+        $json = json_decode($response->getBody()->getContents(), true, JSON_THROW_ON_ERROR);
+
         if ($json === null) {
             throw new ResponseException('Unable to parse response string as JSON');
         }


### PR DESCRIPTION
in our application, I use middleware when I track the request and response in order to keep the log files

since I get the null after that I always get the exception 'Unable to parse response string as JSON'

refer to: https://github.com/8p/EightPointsGuzzleBundle/issues/48#issue-158996179

we need to add $response->getBody()->rewind();
